### PR TITLE
fix: timestamp for points stored and retrieved as int

### DIFF
--- a/lambda-backend/src/components/mongo/index.js
+++ b/lambda-backend/src/components/mongo/index.js
@@ -14,7 +14,7 @@ module.exports = config => {
 			debug(`Getting latest mood points from mongo for team ${team}...`);
 			const points = await db.collection('points').find({ team }).toArray();
 			return points.map(point => ({
-				timestamp: new Date(parseInt(point.timestamp, 10)),
+				timestamp: point.timestamp,
 				x: point.x,
 				y: point.y,
 			}));

--- a/lambda-backend/src/components/s3/index.js
+++ b/lambda-backend/src/components/s3/index.js
@@ -30,7 +30,7 @@ module.exports = ({ bucket }) => {
 		const toPoint = pid => {
 			const [,, x, y, timestamp] = pid.split(':');
 			return {
-				timestamp: timestamp,
+				timestamp,
 				x,
 				y,
 			};

--- a/lambda-backend/src/components/s3/index.js
+++ b/lambda-backend/src/components/s3/index.js
@@ -30,7 +30,7 @@ module.exports = ({ bucket }) => {
 		const toPoint = pid => {
 			const [,, x, y, timestamp] = pid.split(':');
 			return {
-				timestamp: new Date(parseInt(timestamp, 10)),
+				timestamp: timestamp,
 				x,
 				y,
 			};


### PR DESCRIPTION
## What’s the focus of this PR
This PR fixes a misunderstanding related to points.timestamp format. We are storing it as an int and frontend expects it as an int. However, the mongo and s3 components are creating a "date" string and passing it to the frontend, so the frontend cannot process opacities properly (opacity value is NaN)

## How to review this PR
Just check the change in stores not parsing unnecessarily the timestamp stored, because frontend doesn´t need a Date object/string.

Before submitting this PR, I made sure:

- [x] The code builds clean without any errors or warnings
