### PR TITLE
feat: Tooltip for identifying teams while hovering points on global view

### DIFF
--- a/lambda-backend/src/components/mongo/index.js
+++ b/lambda-backend/src/components/mongo/index.js
@@ -14,11 +14,7 @@ module.exports = config => {
 			debug(`Getting latest mood points from mongo for team ${team}...`);
 			const query = team === config.globalTeam ? {} : { team };
 			const points = await db.collection('points').find(query).toArray();
-			return points.map(point => ({
-				timestamp: point.timestamp,
-				x: point.x,
-				y: point.y,
-			}));
+			return points.map(({timestamp, x, y, team }) => ({ timestamp, x, y, team }));
 		};
 
 		const register = async point => {

--- a/lambda-backend/src/components/server/index.js
+++ b/lambda-backend/src/components/server/index.js
@@ -6,6 +6,13 @@ module.exports = ({ port }) => {
 		const app = express();
 		app.use(bodyParser.json());
 
+		app.use((req, res, next) => {
+			res.header("Access-Control-Allow-Origin", "*");
+			res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+			res.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE");
+			return next();
+		});
+
 		app.get('/:team/points', async (req, res) => {
 			const team = req.params.team.toLowerCase();
 			const points = await controller.checkMood(team);

--- a/static/team.html
+++ b/static/team.html
@@ -98,11 +98,16 @@
   };
 
   function drawPoint(team, x, y, timestamp, pid = null) {
-    const point = $(('<img>')).attr('src', 'point.png')
+    const point = $(('<img>'))
+      .attr('src', 'point.png')
       .addClass('point')
       .css('width', POINT_DIAMETER + 'px')
       .css('left', x - POINT_DIAMETER / 2)
-      .css('top', y - POINT_DIAMETER / 2);
+      .css('top', y - POINT_DIAMETER / 2)
+      .tooltip({
+				html: true,
+        title: `<h5>${team}</h5><p>${new Date(timestamp).toISOString().slice(0,10)}</p>`
+      });
 
     const timeDiff = Date.now() - timestamp;
     const opacity = 1 - 0.025 * timeDiff / (6 * 60 * 60 * 1000);  // substract 0.025 each 6h
@@ -123,7 +128,7 @@
 
   function loadPoints(team) {
     $.get(BACKEND_BASE + '/' + team + '/points')
-      .done(points => points.forEach(point => drawPoint(team, point.x, point.y, point.timestamp)))
+      .done(points => points.forEach(point => drawPoint(point.team, point.x, point.y, point.timestamp)))
       .fail(err => alert('Error loading your team\'s mood'));
   }
 
@@ -147,20 +152,22 @@
 
       const x = Math.round(e.clientX - bounds.left);
       const y = Math.round(e.clientY - bounds.top);
-			const tags = getTags(x-bounds.width/2, bounds.height/2-y);
+      const tags = getTags(x-bounds.width/2, bounds.height/2-y);
 
-			if (Object.values(tags).every(tag=>tag===null)) return;
+      if (Object.values(tags).every(tag=>tag===null)) return;
 
       const point = { x, y, ...tags };
 
-      $.ajax({
-        url: BACKEND_BASE + '/' + team + '/points',
-        type: 'POST',
-        data: JSON.stringify(point),
-        dataType: 'json'
+      fetch(BACKEND_BASE + '/' + team + '/points', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(point),
       })
-        .done(result => drawPoint(team, x, y, Date.now(), result.pid))
-        .fail(err => alert('Error saving your mood'));
+        .then(response => response.json())
+        .then(data => drawPoint(team, x, y, Date.now(), data.pid))
+        .catch(err => alert('Error saving your mood'));
     });
   });
   </script>

--- a/static/team.html
+++ b/static/team.html
@@ -117,9 +117,9 @@
       point.data('pid', pid).addClass('mine');
 
       point.on('click', (e) => {
-        $.ajax({url: BACKEND_BASE + '/' + team + '/points/' + pid, type: 'DELETE'})
-          .done(res => $(e.target).remove())
-          .fail(err => alert('Error removing mood point'));
+				fetch(BACKEND_BASE + '/' + team + '/points/' + pid, {method: 'DELETE'})
+          .then(res => $(e.target).remove())
+          .catch(err => alert('Error removing mood point'));
       });
     }
 
@@ -127,9 +127,10 @@
   }
 
   function loadPoints(team) {
-    $.get(BACKEND_BASE + '/' + team + '/points')
-      .done(points => points.forEach(point => drawPoint(point.team, point.x, point.y, point.timestamp)))
-      .fail(err => alert('Error loading your team\'s mood'));
+		fetch(BACKEND_BASE + '/' + team + '/points', {method: 'GET'})
+			.then(response => response.json())
+      .then(points => points.forEach(point => drawPoint(point.team, point.x, point.y, point.timestamp)))
+      .catch(err => alert('Error loading your team\'s mood'));
   }
 
   $(document).ready(() => {


### PR DESCRIPTION
## What’s the focus of this PR
This PR adds the ability to display a tooltip while hovering a point. This tooltip displays team name for that point and its date as per @jadorado request.
<img width="742" alt="Screenshot 2020-08-17 at 11 26 20" src="https://user-images.githubusercontent.com/43818056/90384312-a4e38a80-e081-11ea-98cf-ac8b40ed552a.png">

It also starts getting rid of jquery stuff by removing ajax methods and using native browser's fetch API.

## How to review this PR
Check tooltip jquery method.
Check backend update for sending point.team data along with coords and timestamp.
Check native fetch use instead of jquery's ajax one.

Before submitting this PR, I made sure:

- [x] The code builds clean without any errors or warnings